### PR TITLE
Updated to use long (int64) for integer data type

### DIFF
--- a/NRedisGraph/Header.cs
+++ b/NRedisGraph/Header.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using StackExchange.Redis;
 
@@ -38,6 +39,7 @@ namespace NRedisGraph
         /// Collection of the schema types present in the header.
         /// </summary>
         /// <value></value>
+        [Obsolete("SchemaType is no longer supported after RedisGraph 2.1 and will always return COLUMN_SCALAR")]
         public List<ResultSetColumnTypes> SchemaTypes { get; }
 
         /// <summary>

--- a/NRedisGraph/ResultSet.cs
+++ b/NRedisGraph/ResultSet.cs
@@ -16,7 +16,7 @@ namespace NRedisGraph
             VALUE_UNKNOWN,
             VALUE_NULL,
             VALUE_STRING,
-            VALUE_INTEGER,
+            VALUE_INT64,
             VALUE_BOOLEAN,
             VALUE_DOUBLE,
             VALUE_ARRAY,
@@ -183,8 +183,8 @@ namespace NRedisGraph
                     return bool.Parse((string)rawScalarData[1]);
                 case ResultSetScalarType.VALUE_DOUBLE:
                     return (double)rawScalarData[1];
-                case ResultSetScalarType.VALUE_INTEGER:
-                    return (int)rawScalarData[1];
+                case ResultSetScalarType.VALUE_INT64:
+                    return (long)rawScalarData[1];
                 case ResultSetScalarType.VALUE_STRING:
                     return (string)rawScalarData[1];
                 case ResultSetScalarType.VALUE_ARRAY:


### PR DESCRIPTION
Resolved test issues with int64
Resolved test issues with columnType field which was deprecated in RedisGraph 2.1+
Closes #9 