### PR TITLE
Bug: Culture inveriance required

### DIFF
--- a/NRedisGraph.Tests/BaseTest.cs
+++ b/NRedisGraph.Tests/BaseTest.cs
@@ -4,6 +4,8 @@ namespace NRedisGraph.Tests
 {
     public abstract class BaseTest : IDisposable
     {
+        public string RedisConnectionString { get; } = Environment.GetEnvironmentVariable("REDIS_CONNECTION_STRING") ?? "localhost";
+
         protected abstract void BeforeTest();
 
         protected abstract void AfterTest();

--- a/NRedisGraph.Tests/DatabaseExtensions.cs
+++ b/NRedisGraph.Tests/DatabaseExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System;
+using Xunit;
 using System.Threading.Tasks;
 using StackExchange.Redis;
 
@@ -10,9 +11,11 @@ namespace NRedisGraph.Tests
         private IDatabase _db;
         protected override void BeforeTest()
         {
-            _muxr = ConnectionMultiplexer.Connect("localhost");
+            _muxr = ConnectionMultiplexer.Connect(RedisConnectionString);
             _db = _muxr.GetDatabase(0);
         }
+
+        
 
         protected override void AfterTest()
         {

--- a/NRedisGraph.Tests/NRedisGraphErrorTest.cs
+++ b/NRedisGraph.Tests/NRedisGraphErrorTest.cs
@@ -12,7 +12,7 @@ namespace NRedisGraph.Tests
 
         protected override void BeforeTest()
         {
-            _muxr = ConnectionMultiplexer.Connect("localhost");
+            _muxr = ConnectionMultiplexer.Connect(RedisConnectionString);
 
             _api = new RedisGraph(_muxr.GetDatabase(0));
 

--- a/NRedisGraph.Tests/RedisGraphAPITest.cs
+++ b/NRedisGraph.Tests/RedisGraphAPITest.cs
@@ -23,7 +23,7 @@ namespace NRedisGraph.Tests
 
         protected override void BeforeTest()
         {
-            _muxr = ConnectionMultiplexer.Connect("localhost");
+            _muxr = ConnectionMultiplexer.Connect(RedisConnectionString);
 
             _muxr.GetDatabase().Execute("FLUSHDB");
 

--- a/NRedisGraph.Tests/RedisGraphUtilitiesTests.cs
+++ b/NRedisGraph.Tests/RedisGraphUtilitiesTests.cs
@@ -50,6 +50,19 @@ public class RedisGraphUtilitiesTests
 
             new object[]
             {
+                new Dictionary<string, object> {{"param", 2.42m}},
+                "CYPHER param=2.42 RETURN $param"
+            },
+
+
+            new object[]
+            {
+                new Dictionary<string, object> {{"param", 2.2f}},
+                "CYPHER param=2.2 RETURN $param"
+            },
+
+            new object[]
+            {
                 new Dictionary<string, object> {{"param", true}},
                 "CYPHER param=true RETURN $param"
             },
@@ -89,7 +102,13 @@ public class RedisGraphUtilitiesTests
                 new Dictionary<string, object> {{"param", new List<int> {1, 2, 3}}},
                 "CYPHER param=[1, 2, 3] RETURN $param"
             },
-            
+
+            new object[]
+            {
+                new Dictionary<string, object> {{"param", new List<decimal> {1, 2.2m, 3.3m}}},
+                "CYPHER param=[1, 2.2, 3.3] RETURN $param"
+            },
+
             new object[]
             {
                 new Dictionary<string, object> {{"param", new[] {"1", "2", "3"}}},

--- a/NRedisGraph/Node.cs
+++ b/NRedisGraph/Node.cs
@@ -97,7 +97,7 @@ namespace NRedisGraph
             sb.Append(", id=");
             sb.Append(Id);
             sb.Append(", propertyMap={");
-            sb.Append(string.Join(", ", PropertyMap.Select(pm => $"{pm.Key}={pm.Value.ToString()}")));
+            sb.Append(string.Join(", ", PropertyMap.Select(pm => $"{pm.Key}={pm.Value}")));
             sb.Append("}}");
 
             return sb.ToString();

--- a/NRedisGraph/Property.cs
+++ b/NRedisGraph/Property.cs
@@ -95,15 +95,9 @@ namespace NRedisGraph
             stringResult.Append(Name);
             stringResult.Append('\'');
             stringResult.Append(", value=");
+            stringResult.Append(RedisGraphUtilities.ValueToStringNoQuotes(Value));
 
-            if (Value == null)
-            {
-                stringResult.Append("null");
-            }
-            else
-            {
-                stringResult.Append(Value);
-            }
+           
 
             stringResult.Append('}');
 

--- a/NRedisGraph/RedisGraphUtilities.cs
+++ b/NRedisGraph/RedisGraphUtilities.cs
@@ -1,4 +1,5 @@
-﻿using System.Text;
+﻿using System;
+using System.Text;
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
@@ -23,8 +24,23 @@ namespace NRedisGraph
 
             return preparedQuery.ToString();
         }
-        
-        internal static string ValueToString(object value)
+
+        public static string ValueToStringNoQuotes(object value)
+        {
+            if (value == null)
+            {
+                return "null";
+            }
+
+            if (value is IConvertible floatValue)
+            {
+                return ConvertibleToString(floatValue);
+            }
+
+            return value.ToString();
+        }
+
+        public static string ValueToString(object value)
         {
             if (value == null)
             {
@@ -56,7 +72,7 @@ namespace NRedisGraph
                 }
             }
 
-            if ((value is System.Collections.IList valueList) && value.GetType().IsGenericType)
+            if ((value is IList valueList) && value.GetType().IsGenericType)
             {
                 var objectValueList = new List<object>();
 
@@ -67,30 +83,25 @@ namespace NRedisGraph
 
                 return ArrayToString(objectValueList.ToArray());
             }
-
+            
             if (value is bool boolValue)
             {
                 return boolValue.ToString().ToLowerInvariant();
             }
 
-            if (value is float floatValue)
+            if (value is IConvertible floatValue)
             {
-                return floatValue.ToString(CultureInfo.InvariantCulture);
+                return ConvertibleToString(floatValue);
             } 
-
-            if (value is decimal decimalValue)
-            {
-                return decimalValue.ToString(CultureInfo.InvariantCulture);
-            }
-
-            if (value is double doubleValue)
-            {
-                return doubleValue.ToString(CultureInfo.InvariantCulture);
-            }
-
+            
             return value.ToString();
         }
-        
+
+        private static string ConvertibleToString(IConvertible floatValue)
+        {
+            return floatValue.ToString(CultureInfo.InvariantCulture);
+        }
+
         private static string ArrayToString(object[] array)
         {
             var arrayElements = array.Select(x =>
@@ -127,5 +138,7 @@ namespace NRedisGraph
 
             return quotedString.ToString();
         }
+
+       
     }
 }

--- a/NRedisGraph/RedisGraphUtilities.cs
+++ b/NRedisGraph/RedisGraphUtilities.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.Globalization;
 
 namespace NRedisGraph
 {
@@ -70,6 +71,21 @@ namespace NRedisGraph
             if (value is bool boolValue)
             {
                 return boolValue.ToString().ToLowerInvariant();
+            }
+
+            if (value is float floatValue)
+            {
+                return floatValue.ToString(CultureInfo.InvariantCulture);
+            } 
+
+            if (value is decimal decimalValue)
+            {
+                return decimalValue.ToString(CultureInfo.InvariantCulture);
+            }
+
+            if (value is double doubleValue)
+            {
+                return doubleValue.ToString(CultureInfo.InvariantCulture);
             }
 
             return value.ToString();


### PR DESCRIPTION
I ran into a problem when trying to use decimal values as parameters. It turns out it is because I'm based in South Africa and the converter did not consider culture.

When I run the tests I get the following results:

```txt
Xunit.Sdk.EqualException: Assert.Equal() Failure
                        ↓ (pos 14)
Expected: CYPHER param=2.3 RETURN $param
Actual:   CYPHER param=2,3 RETURN $param
                        ↑ (pos 14)
```

I've added a fix for the issue. 

In dotnet6 I would probably consider using the internal JSON converter for that function.